### PR TITLE
Seeding Categories table

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,8 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         // $this->call(UserSeeder::class);
+        $this->call(CategoriesTableSeeder::class);
+        // without the above line you would have to run
+        // php artisan db:seed --class=CategoriesTableSeeder
     }
 }


### PR DESCRIPTION
Without  `$this->call(CategoriesTableSeeder::class)`  the `Categories` table would be still empty ( not seeded ).
You could run `php artisan db:seed --class=CategoriesTableSeeder` instead, and add that command to `README.md` file
but it is easier to do the seeding here and not  to modify `README.md`.